### PR TITLE
adding check for nsfw, if so, don't save the image or upsample

### DIFF
--- a/stable_diffusion_videos/stable_diffusion_walk.py
+++ b/stable_diffusion_videos/stable_diffusion_walk.py
@@ -188,7 +188,7 @@ def walk(
             latents = slerp(float(t), latents_a, latents_b)
 
             with torch.autocast("cuda"):
-                im = pipeline(
+                outputs = pipeline(
                     latents=latents,
                     text_embeddings=embeds,
                     height=height,
@@ -197,8 +197,13 @@ def walk(
                     eta=eta,
                     num_inference_steps=num_inference_steps,
                     output_type='pil' if not upsample else 'numpy'
-                )["sample"][0]
+                )
 
+                if any(outputs["nsfw_content_detected"]):
+                    # nothing to do here, don't increase frame index either
+                    continue
+
+                im = outputs["sample"][0]
                 if upsample:
                     im = upsampling_pipeline(im)
 


### PR DESCRIPTION
In the case of NSFW output, I don't think we want to save the image or increase the frame index, it makes the video weird. Should this parameterized? Should we potentially retry with a slight change? Maybe even more complex, if before/after are NOT NSFW, then just move slightly in latent space?