### PR TITLE
Add option for lower VRAM

### DIFF
--- a/stable_diffusion_videos/stable_diffusion_pipeline.py
+++ b/stable_diffusion_videos/stable_diffusion_pipeline.py
@@ -36,6 +36,33 @@ class StableDiffusionPipeline(DiffusionPipeline):
             safety_checker=safety_checker,
             feature_extractor=feature_extractor,
         )
+    
+    def enable_attention_slicing(self, slice_size: Optional[Union[str, int]] = "auto"):
+        r"""
+        Enable sliced attention computation.
+
+        When this option is enabled, the attention module will split the input tensor in slices, to compute attention
+        in several steps. This is useful to save some memory in exchange for a small speed decrease.
+
+        Args:
+            slice_size (`str` or `int`, *optional*, defaults to `"auto"`):
+                When `"auto"`, halves the input to the attention heads, so attention will be computed in two steps. If
+                a number is provided, uses as many slices as `attention_head_dim // slice_size`. In this case,
+                `attention_head_dim` must be a multiple of `slice_size`.
+        """
+        if slice_size == "auto":
+            # half the attention head size is usually a good trade-off between
+            # speed and memory
+            slice_size = self.unet.config.attention_head_dim // 2
+        self.unet.set_attention_slice(slice_size)
+
+    def disable_attention_slicing(self):
+        r"""
+        Disable sliced attention computation. If `enable_attention_slicing` was previously invoked, this method will go
+        back to computing attention in one step.
+        """
+        # set slice_size = `None` to disable `attention slicing`
+        self.enable_attention_slicing(None)
 
     @torch.no_grad()
     def __call__(

--- a/stable_diffusion_videos/stable_diffusion_walk.py
+++ b/stable_diffusion_videos/stable_diffusion_walk.py
@@ -88,6 +88,7 @@ def walk(
     disable_tqdm=False,
     upsample=False,
     fps=30,
+    less_vram=False,
 ):
     """Generate video frames/a video given a list of prompts and seeds.
 
@@ -110,6 +111,7 @@ def walk(
         upsample (bool, optional): If True, uses Real-ESRGAN to upsample images 4x. Requires it to be installed
             which you can do by running: `pip install git+https://github.com/xinntao/Real-ESRGAN.git`. Defaults to False.
         fps (int, optional): The frames per second (fps) that you want the video to use. Does nothing if make_video is False. Defaults to 30.
+        less_vram (bool, optional): Allow higher resolution output on smaller GPUs. Yields same result at the expense of 10% speed. Defaults to False.
 
     Returns:
         str: Path to video file saved if make_video=True, else None.
@@ -118,6 +120,9 @@ def walk(
         from .upsampling import PipelineRealESRGAN
 
         upsampling_pipeline = PipelineRealESRGAN.from_pretrained('nateraw/real-esrgan')
+
+    if less_vram:
+        pipeline.enable_attention_slicing()
 
     pipeline.set_progress_bar_config(disable=disable_tqdm)
 


### PR DESCRIPTION
Enable sliced attention computation using less_vram=True.

`enable_attention_slicing()` and `disable_attention_slicing()` are copied from the latest diffusers library.