### PR TITLE
Resume support

### DIFF
--- a/stable_diffusion_videos/__init__.py
+++ b/stable_diffusion_videos/__init__.py
@@ -111,6 +111,7 @@ __getattr__, __dir__, __all__ = _attach(
         ],
         "stable_diffusion_walk": [
             "walk",
+            "resume",
             "SCHEDULERS",
             "pipeline",
         ],

--- a/stable_diffusion_videos/app.py
+++ b/stable_diffusion_videos/app.py
@@ -3,7 +3,7 @@ import time
 import gradio as gr
 import torch
 
-from .stable_diffusion_walk import SCHEDULERS, pipeline, walk
+from .stable_diffusion_walk import SCHEDULERS, pipeline, walk, resume
 
 
 def fn_images(

--- a/stable_diffusion_videos/stable_diffusion_walk.py
+++ b/stable_diffusion_videos/stable_diffusion_walk.py
@@ -106,8 +106,8 @@ def resume(
         num_steps=data['num_steps'],
         output_dir=output_dir,
         name=data['name'],
-        height=data['height'] if not data.has_key('height') else height,
-        width=data['width'] if not data.has_key('height') else width,
+        height=data['height'] if 'height' in data else height,
+        width=data['width'] if 'width' in data else width,
         guidance_scale=data['guidance_scale'],
         eta=data['eta'],
         num_inference_steps=data['num_inference_steps'],
@@ -116,8 +116,8 @@ def resume(
         use_lerp_for_text=data['use_lerp_for_text'],
         scheduler=data['scheduler'],
         disable_tqdm=disable_tqdm,
-        upsample=data['upsample'] if not data.has_key('upsample') else upsample,
-        fps=data['fps'] if not data.has_key('height') else fps,
+        upsample=data['upsample'] if 'upsample' in data else upsample,
+        fps=data['fps'] if 'fps' in data else fps,
     )
     return
 

--- a/stable_diffusion_videos/stable_diffusion_walk.py
+++ b/stable_diffusion_videos/stable_diffusion_walk.py
@@ -74,6 +74,10 @@ def resume(
     output_dir="dreams",
     name="berry_good_spaghetti",
     disable_tqdm=False,
+    height=512,
+    width=512,
+    upsample=False,
+    fps=30,
 ):
     """Generate video frames/a video given a list of prompts and seeds.
 
@@ -81,6 +85,15 @@ def resume(
         output_dir (str, optional): Root dir where images will be saved. Defaults to "dreams".
         name (str, optional): Sub directory of output_dir to save this run's files. Defaults to "berry_good_spaghetti".
         disable_tqdm (bool, optional): Whether to turn off the tqdm progress bars. Defaults to False.
+        height (int, optional): Height of image to generate. Defaults to 512.
+            ONLY USED IF NOT SAVED.
+        width (int, optional): Width of image to generate. Defaults to 512.
+            ONLY USED IF NOT SAVED.
+        upsample (bool, optional): If True, uses Real-ESRGAN to upsample images 4x. Requires it to be installed
+            which you can do by running: `pip install git+https://github.com/xinntao/Real-ESRGAN.git`.
+            Defaults to False. ONLY USED IF NOT SAVED.
+        fps (int, optional): The frames per second (fps) that you want the video to use. Does nothing if make_video is False.
+            Defaults to 30. ONLY USED IF NOT SAVED.
 
     Returns:
         str: Path to video file saved if make_video=True, else None.
@@ -93,8 +106,8 @@ def resume(
         num_steps=data['num_steps'],
         output_dir=output_dir,
         name=data['name'],
-        height=data['height'],
-        width=data['width'],
+        height=data['height'] if not data.has_key('height') else height,
+        width=data['width'] if not data.has_key('height') else width,
         guidance_scale=data['guidance_scale'],
         eta=data['eta'],
         num_inference_steps=data['num_inference_steps'],
@@ -103,8 +116,8 @@ def resume(
         use_lerp_for_text=data['use_lerp_for_text'],
         scheduler=data['scheduler'],
         disable_tqdm=disable_tqdm,
-        upsample=data['upsample'],
-        fps=data['fps'],
+        upsample=data['upsample'] if not data.has_key('upsample') else upsample,
+        fps=data['fps'] if not data.has_key('height') else fps,
     )
     return
 

--- a/stable_diffusion_videos/stable_diffusion_walk.py
+++ b/stable_diffusion_videos/stable_diffusion_walk.py
@@ -266,7 +266,7 @@ def walk(
                 if upsample:
                     im = upsampling_pipeline(im)
 
-            im.save(imgname)
+            im.save(frame_filepath)
 
         embeds_a = embeds_b
         latents_a = latents_b

--- a/stable_diffusion_videos/stable_diffusion_walk.py
+++ b/stable_diffusion_videos/stable_diffusion_walk.py
@@ -70,6 +70,45 @@ def make_video_ffmpeg(frame_dir, output_file_name='output.mp4', frame_filename="
     return video_path
 
 
+def resume(
+    output_dir="dreams",
+    name="berry_good_spaghetti",
+    disable_tqdm=False,
+):
+    """Generate video frames/a video given a list of prompts and seeds.
+
+    Args:
+        output_dir (str, optional): Root dir where images will be saved. Defaults to "dreams".
+        name (str, optional): Sub directory of output_dir to save this run's files. Defaults to "berry_good_spaghetti".
+        disable_tqdm (bool, optional): Whether to turn off the tqdm progress bars. Defaults to False.
+
+    Returns:
+        str: Path to video file saved if make_video=True, else None.
+    """
+    prompt_config_path = Path(output_dir) / name / 'prompt_config.json'
+    data = json.load(open(prompt_config_path))
+    walk(
+        prompts=data['prompts'],
+        seeds=data['seeds'],
+        num_steps=data['num_steps'],
+        output_dir=output_dir,
+        name=data['name'],
+        height=data['height'],
+        width=data['width'],
+        guidance_scale=data['guidance_scale'],
+        eta=data['eta'],
+        num_inference_steps=data['num_inference_steps'],
+        do_loop=data['do_loop'],
+        make_video=data['make_video'],
+        use_lerp_for_text=data['use_lerp_for_text'],
+        scheduler=data['scheduler'],
+        disable_tqdm=disable_tqdm,
+        upsample=data['upsample'],
+        fps=data['fps'],
+    )
+    return
+
+
 def walk(
     prompts=["blueberry spaghetti", "strawberry spaghetti"],
     seeds=[42, 123],
@@ -126,27 +165,32 @@ def walk(
     output_path = Path(output_dir) / name
     output_path.mkdir(exist_ok=True, parents=True)
 
-    # Write prompt info to file in output dir so we can keep track of what we did
+    # Write prompt info to file in output dir so we can keep track of what we did, if it doesn't exist
     prompt_config_path = output_path / 'prompt_config.json'
-    prompt_config_path.write_text(
-        json.dumps(
-            dict(
-                prompts=prompts,
-                seeds=seeds,
-                num_steps=num_steps,
-                name=name,
-                guidance_scale=guidance_scale,
-                eta=eta,
-                num_inference_steps=num_inference_steps,
-                do_loop=do_loop,
-                make_video=make_video,
-                use_lerp_for_text=use_lerp_for_text,
-                scheduler=scheduler
-            ),
-            indent=2,
-            sort_keys=False,
+    if not prompt_config_path.is_file():
+        prompt_config_path.write_text(
+            json.dumps(
+                dict(
+                    prompts=prompts,
+                    seeds=seeds,
+                    num_steps=num_steps,
+                    name=name,
+                    guidance_scale=guidance_scale,
+                    eta=eta,
+                    num_inference_steps=num_inference_steps,
+                    do_loop=do_loop,
+                    make_video=make_video,
+                    use_lerp_for_text=use_lerp_for_text,
+                    scheduler=scheduler,
+                    upsample=upsample,
+                    fps=fps,
+                    height=height,
+                    width=width,
+                ),
+                indent=2,
+                sort_keys=False,
+            )
         )
-    )
 
     assert len(prompts) == len(seeds)
 
@@ -181,11 +225,18 @@ def walk(
             if do_print_progress:
                 print(f"COUNT: {frame_index+1}/{len(seeds)*num_steps}")
 
+            imgname = output_path / ("frame%06d.jpg" % frame_index)
+            frame_index += 1
+
             if use_lerp_for_text:
                 embeds = torch.lerp(embeds_a, embeds_b, float(t))
             else:
                 embeds = slerp(float(t), embeds_a, embeds_b)
             latents = slerp(float(t), latents_a, latents_b)
+
+            if imgname.is_file():
+                print("Skip ", frame_index, end='\r')
+                continue
 
             with torch.autocast("cuda"):
                 im = pipeline(
@@ -202,8 +253,7 @@ def walk(
                 if upsample:
                     im = upsampling_pipeline(im)
 
-            im.save(output_path / ("frame%06d.jpg" % frame_index))
-            frame_index += 1
+            im.save(imgname)
 
         embeds_a = embeds_b
         latents_a = latents_b

--- a/stable_diffusion_videos/stable_diffusion_walk.py
+++ b/stable_diffusion_videos/stable_diffusion_walk.py
@@ -247,7 +247,7 @@ def walk(
                 embeds = slerp(float(t), embeds_a, embeds_b)
             latents = slerp(float(t), latents_a, latents_b)
 
-            if imgname.is_file():
+            if frame_filepath.is_file():
                 print("Skip ", frame_index, end='\r')
                 continue
 

--- a/stable_diffusion_videos/stable_diffusion_walk.py
+++ b/stable_diffusion_videos/stable_diffusion_walk.py
@@ -238,7 +238,7 @@ def walk(
             if do_print_progress:
                 print(f"COUNT: {frame_index+1}/{len(seeds)*num_steps}")
 
-            imgname = output_path / ("frame%06d.jpg" % frame_index)
+            frame_filepath = output_path / ("frame%06d.jpg" % frame_index)
             frame_index += 1
 
             if use_lerp_for_text:


### PR DESCRIPTION
Add resume support. Last night I started a 10,000 image sequence. This morning's regret is today's feature, I wrote this to resume from the previous outputs without modification. As an incidental bonus, it'll redo missing images in the chain.

Background;
- It's all seeded, image generation can be considered deterministic given static dataset and params. We just need to fast-forward to where we left off. We don't need to store progress -- we follow a filename pattern, so we just skip until we find something missing.

Side benefits;
- Re-run old videos with appended prompts/seeds, a different framerate, etc, with simple json edits

New 'resume' function;
- only requires name, output_dir; uses existing defaults
- detects all other settings from written json, fills in missing params from prev-written pre-existing defaults
- minimal code path, relies mostly on existing code

Modification to 'walk' function;
- skips writing json if exists
- adds missing params to json write
- skips generating/writing image if exists
- avoids skipping other steps, effectively zero behavioral change

Potentially needing addressed;
- does not write missing infos to json if json was written without them