### PR TITLE
added M1 support

### DIFF
--- a/stable_diffusion_videos/devices.py
+++ b/stable_diffusion_videos/devices.py
@@ -1,0 +1,9 @@
+import torch
+
+def choose_torch_device() -> str:
+    '''Convenience routine for guessing which GPU device to run model on'''
+    if torch.cuda.is_available():
+        return 'cuda'
+    if torch.backends.mps.is_available():
+        return 'mps'
+    return 'cpu'


### PR DESCRIPTION
Fixes #38

## environment
I used the environment defined by [INSTALL_MAC.md](https://github.com/lstein/stable-diffusion/blob/main/docs/installation/INSTALL_MAC.md) and in [environment-mac.yaml](https://github.com/lstein/stable-diffusion/blob/main/environment-mac.yaml).

## What did i do?

I added a method that choose the correct torch device. It could be easily extended to support other backends to like:
- torch.backends.mkl
- torch.backends.mkldnn
- torch.backends.openmp

```python
def choose_torch_device() -> str:
    '''Convenience routine for guessing which GPU device to run model on'''
    if torch.cuda.is_available():
        return 'cuda'
    if torch.backends.mps.is_available():
        return 'mps'
    return 'cpu'
 ```
 
 Furthermore, i needed to blacklist fp16 for mps, since it does only support fp32 currently and use another device for noice generation, since the generator does not support mps.
 
 Lastly i tested it with `upscaling = False` since there is still a bug in the `realesrgan` packackages convolutions, that not supported on mps (M1).
```
  File "/Users/langhalsdino/github/temp/stable-diffusion-videos/stable_diffusion_videos/upsampling.py", line 48, in __call__
    image, _ = self.upsampler.enhance(img, outscale=outscale)
  File "/Users/langhalsdino/miniforge3/envs/ldm/lib/python3.9/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/Users/langhalsdino/miniforge3/envs/ldm/lib/python3.9/site-packages/realesrgan/utils.py", line 190, in enhance
    self.process()
  File "/Users/langhalsdino/miniforge3/envs/ldm/lib/python3.9/site-packages/realesrgan/utils.py", line 82, in process
    self.output = self.model(self.img)
  File "/Users/langhalsdino/miniforge3/envs/ldm/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1190, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/langhalsdino/miniforge3/envs/ldm/lib/python3.9/site-packages/basicsr/archs/rrdbnet_arch.py", line 112, in forward
    feat = self.conv_first(feat)
  File "/Users/langhalsdino/miniforge3/envs/ldm/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1190, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/langhalsdino/miniforge3/envs/ldm/lib/python3.9/site-packages/torch/nn/modules/conv.py", line 463, in forward
    return self._conv_forward(input, self.weight, self.bias)
  File "/Users/langhalsdino/miniforge3/envs/ldm/lib/python3.9/site-packages/torch/nn/modules/conv.py", line 459, in _conv_forward
    return F.conv2d(input, weight, bias, self.stride,
RuntimeError: "slow_conv2d_cpu" not implemented for 'Half'
```