### PR TITLE
Save in .png instead of .jpg

### DIFF
--- a/stable_diffusion_videos/stable_diffusion_walk.py
+++ b/stable_diffusion_videos/stable_diffusion_walk.py
@@ -274,7 +274,7 @@ def walk(
                 else:
                     images = outputs
             for image in images:
-                frame_filepath = output_path / ("frame%06d.jpg" % frame_index)
+                frame_filepath = output_path / ("frame%06d.png" % frame_index)
                 image.save(frame_filepath)
                 frame_index += 1
 

--- a/stable_diffusion_videos/stable_diffusion_walk.py
+++ b/stable_diffusion_videos/stable_diffusion_walk.py
@@ -60,7 +60,7 @@ def slerp(t, v0, v1, DOT_THRESHOLD=0.9995):
     return v2
 
 
-def make_video_ffmpeg(frame_dir, output_file_name='output.mp4', frame_filename="frame%06d.jpg", fps=30):
+def make_video_ffmpeg(frame_dir, output_file_name='output.mp4', frame_filename="frame%06d.png", fps=30):
     frame_ref_path = str(frame_dir / frame_filename)
     video_path = str(frame_dir / output_file_name)
     subprocess.call(
@@ -178,7 +178,7 @@ def walk(
         upsample = data['upsample'] if 'upsample' in data else upsample
         fps = data['fps'] if 'fps' in data else fps
 
-        resume_step = int(sorted(output_path.glob("frame*.jpg"))[-1].stem[5:])
+        resume_step = int(sorted(output_path.glob("frame*.png"))[-1].stem[5:])
         print(f"\nResuming {output_path} from step {resume_step}...")
 
 
@@ -220,7 +220,7 @@ def walk(
 
         for i, t in enumerate(np.linspace(0, 1, num_steps)):
 
-            frame_filepath = output_path / ("frame%06d.jpg" % frame_index)
+            frame_filepath = output_path / ("frame%06d.png" % frame_index)
             frame_index += 1
 
             if resume and frame_filepath.is_file():

--- a/stable_diffusion_videos/upsampling.py
+++ b/stable_diffusion_videos/upsampling.py
@@ -78,7 +78,7 @@ class PipelineRealESRGAN:
         return cls(file)
 
 
-    def upsample_imagefolder(self, in_dir, out_dir, suffix='out', outfile_ext='.jpg'):
+    def upsample_imagefolder(self, in_dir, out_dir, suffix='out', outfile_ext='.png'):
         in_dir, out_dir = Path(in_dir), Path(out_dir)
         if not in_dir.exists():
             raise FileNotFoundError(f"Provided input directory {in_dir} does not exist")


### PR DESCRIPTION
Hey @nateraw,

I was waiting for the resuming feature to merge. Didn't want to muddle the waters.

I ran some comparisons on saving in .png versus .jpg. In general, png format has  smoother color gradients and less artifacts. This is especially obvious after upsampling.

See the example below. Both generated at 960x512 and then upsampled 4x. Screeshot at 100% zoom. png on the left and jpg on the right. Click to view full-size.

![image](https://user-images.githubusercontent.com/4979897/191413707-ea78b388-18d3-42ce-bba8-820c787abde5.png)

The only drawback of png is larger size. At default compression levels, png is 8-9mb at 4k resolution while jpg is at 500-750kb. But considering the compute and time spent on generating these images, I feel we should prioritize image quality over file size. 

I also tried different png compression levels. The visual difference is minimal so I went with the [default](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png).

What do you think?