### PR TITLE
Add batch inference

### DIFF
--- a/stable_diffusion_videos/stable_diffusion_walk.py
+++ b/stable_diffusion_videos/stable_diffusion_walk.py
@@ -261,7 +261,7 @@ def walk(
                     eta=eta,
                     num_inference_steps=num_inference_steps,
                     output_type='pil' if not upsample else 'numpy'
-                )["sample"]  #  [0]
+                )["sample"]
 
                 del embeds_batch
                 del latents_batch


### PR DESCRIPTION
This PR lets you do batch inference. Previously, we were generating 1 image at a time while making videos. Now, you should be able to generate `batch_size` number of frames at a time. Suggest to increase this to a value 1 less than what makes you run out of VRAM. For me, that's 4 on a V100 16GB. 