### PR TITLE
Update README.md for MPS cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ huggingface-cli login
 ```
 
 ### Making Videos
+Note: For Apple M1 architecture, use ```torch.float32``` instead, as ```torch.float16``` is not available on MPS.
 
 ```python
 from stable_diffusion_videos import StableDiffusionWalkPipeline


### PR DESCRIPTION
Adds a small note to change torch_dtype=torch.float16 to torch_dtype=torch.float32 in the case of a Mac M1 (and related).

To be included in #146, "fixes" #125