### PR TITLE
Add `recursive` option to `upsample_imagefolder`

### DIFF
--- a/stable_diffusion_videos/upsampling.py
+++ b/stable_diffusion_videos/upsampling.py
@@ -99,7 +99,7 @@ class RealESRGANModel(nn.Module):
         for i, image in enumerate(image_paths):
             out_filepath = out_dir / (str(image.relative_to(in_dir).with_suffix('')) + suffix + outfile_ext)
             if not force and out_filepath.exists():
-                logger.info(f'[{i}/{n_img}] {out_filepath} already exists')
+                logger.info(f'[{i}/{n_img}] {out_filepath} already exists, skipping. To avoid skipping, pass force=True.')
                 continue
             logger.info(f'[{i}/{n_img}] upscaling {image}')
             im = self(str(image))

--- a/stable_diffusion_videos/upsampling.py
+++ b/stable_diffusion_videos/upsampling.py
@@ -98,7 +98,7 @@ class RealESRGANModel(nn.Module):
         n_img = len(image_paths)
         for i, image in enumerate(image_paths):
             out_filepath = out_dir / (str(image.relative_to(in_dir).with_suffix('')) + suffix + outfile_ext)
-            if out_filepath.exists():
+            if not force and out_filepath.exists():
                 logger.info(f'[{i}/{n_img}] {out_filepath} already exists')
                 continue
             logger.info(f'[{i}/{n_img}] upscaling {image}')


### PR DESCRIPTION
This PR implements a `recursive` option to `RealESRGANModel.upsample_imagefolder` such that all images in subdirectories inside the input directories are upscaled. Currently, only images one level down the input directory are upscaled. This is relevant to this project because `StableDiffusionWalkPipeline.walk` creates subdirectories of images inside the output directory.

Example: the user just created a video using the following code:
```python
pipe.walk(
    prompts=["red cat", "green cat", "red cat"]
    output_dir="dreams",
    name="cats",
    ...
)
```
Now the directory `dreams/` looks like this:
```
dreams
└── cats
    ├── cats_000000
    │   ├── frame000000.png
    │   ├── frame000001.png
    │   ├── frame000002.png
    │   └── ...
    ├── cats_000001
    │   ├── frame000000.png
    │   ├── frame000001.png
    │   ├── frame000002.png
    │   └── ...
    ├── cats.mp4
    └── prompt_config.json
```
Now the user wishes to upscale all the images. Calling `RealESRGANModel.upsample_imagefolder(in_dir="dreams/cats", out_dir="path/to/output_dir")` currently does nothing as there are no images inside `dreams/cats/` (the images are in subfolders). The user currently needs to call the method for each subfolder inside `dreams/cats/`. This PR allows the user to provide `recursive=True` to upscale all images in subfolders without having to call the method for each subfolder. The output directory then presents the same structure as the input directory:
```
path/to/output_dir
├── cats_000000
│   ├── frame000000out.png
│   ├── frame000001out.png
│   ├── frame000002out.png
│   └── ...
└── cats_000001
    ├── frame000000out.png
    ├── frame000001out.png
    ├── frame000002out.png
    └── ...
```  

Other additions:
- Added a `force` option to allow overwriting of output files. Currently, output files are overwritten. With this PR, the default behavior is to skip if the output file already exists, unless `force=True` is provided.
- Added logging. Logs tell if the image is skipped or upscaled, and the current progress (current image number over total number of images)