### PR TITLE
Add `make_video` as an option to `StableDiffusionWalkPipeline.walk`

### DIFF
--- a/stable_diffusion_videos/stable_diffusion_pipeline.py
+++ b/stable_diffusion_videos/stable_diffusion_pipeline.py
@@ -661,6 +661,7 @@ class StableDiffusionWalkPipeline(DiffusionPipeline):
         margin: Optional[float] = 1.0,
         smooth: Optional[float] = 0.0,
         negative_prompt: Optional[str] = None,
+        make_video: Optional[bool] = True,
     ):
         """Generate a video from a sequence of prompts and seeds. Optionally, add audio to the
         video to interpolate to the intensity of the audio.
@@ -864,27 +865,28 @@ class StableDiffusionWalkPipeline(DiffusionPipeline):
                 skip=skip,
                 negative_prompt=negative_prompt,
             )
-            make_video_pyav(
-                save_path,
+            if make_video:
+                make_video_pyav(
+                    save_path,
+                    audio_filepath=audio_filepath,
+                    fps=fps,
+                    output_filepath=step_output_filepath,
+                    glob_pattern=f"*{image_file_ext}",
+                    audio_offset=audio_offset,
+                    audio_duration=audio_duration,
+                    sr=44100,
+                )
+        if make_video:
+            return make_video_pyav(
+                save_path_root,
                 audio_filepath=audio_filepath,
                 fps=fps,
-                output_filepath=step_output_filepath,
-                glob_pattern=f"*{image_file_ext}",
-                audio_offset=audio_offset,
-                audio_duration=audio_duration,
+                audio_offset=audio_start_sec,
+                audio_duration=sum(num_interpolation_steps) / fps,
+                output_filepath=output_filepath,
+                glob_pattern=f"**/*{image_file_ext}",
                 sr=44100,
             )
-
-        return make_video_pyav(
-            save_path_root,
-            audio_filepath=audio_filepath,
-            fps=fps,
-            audio_offset=audio_start_sec,
-            audio_duration=sum(num_interpolation_steps) / fps,
-            output_filepath=output_filepath,
-            glob_pattern=f"**/*{image_file_ext}",
-            sr=44100,
-        )
 
     def embed_text(self, text, negative_prompt=None):
         """Helper to embed some text"""

--- a/stable_diffusion_videos/stable_diffusion_pipeline.py
+++ b/stable_diffusion_videos/stable_diffusion_pipeline.py
@@ -714,6 +714,9 @@ class StableDiffusionWalkPipeline(DiffusionPipeline):
                 Smoothness of the audio interpolation. 1.0 means linear interpolation.
             negative_prompt (Optional[str], *optional*, defaults to None):
                 Optional negative prompt to use. Same across all prompts.
+            make_video (Optional[bool], *optional*, defaults to True):
+                When True, makes a video from the generated frames. If False, only
+                generates the frames.
 
         This function will create sub directories for each prompt and seed pair.
 

--- a/stable_diffusion_videos/upsampling.py
+++ b/stable_diffusion_videos/upsampling.py
@@ -4,6 +4,7 @@ import cv2
 from PIL import Image
 from huggingface_hub import hf_hub_download
 from torch import nn
+from diffusers.utils import logging
 
 try:
     from realesrgan import RealESRGANer
@@ -13,6 +14,8 @@ except ImportError as e:
         "You tried to import realesrgan without having it installed properly. To install Real-ESRGAN, run:\n\n"
         "pip install realesrgan"
     )
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 class RealESRGANModel(nn.Module):
@@ -83,15 +86,22 @@ class RealESRGANModel(nn.Module):
             file = hf_hub_download(model_name_or_path, "RealESRGAN_x4plus.pth")
         return cls(file)
 
-    def upsample_imagefolder(self, in_dir, out_dir, suffix="out", outfile_ext=".png"):
+    def upsample_imagefolder(self, in_dir, out_dir, suffix="out", outfile_ext=".png", recursive=False, force=False):
         in_dir, out_dir = Path(in_dir), Path(out_dir)
         if not in_dir.exists():
             raise FileNotFoundError(f"Provided input directory {in_dir} does not exist")
 
         out_dir.mkdir(exist_ok=True, parents=True)
 
-        image_paths = [x for x in in_dir.glob("*") if x.suffix.lower() in [".png", ".jpg", ".jpeg"]]
-        for image in image_paths:
+        generator = in_dir.rglob("*") if recursive else in_dir.glob("*")
+        image_paths = [x for x in generator if x.suffix.lower() in [".png", ".jpg", ".jpeg"]]
+        n_img = len(image_paths)
+        for i, image in enumerate(image_paths):
+            out_filepath = out_dir / (str(image.relative_to(in_dir).with_suffix('')) + suffix + outfile_ext)
+            if not force and out_filepath.exists():
+                logger.info(f'[{i}/{n_img}] {out_filepath} already exists, skipping. To avoid skipping, pass force=True.')
+                continue
+            logger.info(f'[{i}/{n_img}] upscaling {image}')
             im = self(str(image))
-            out_filepath = out_dir / (image.stem + suffix + outfile_ext)
+            out_filepath.parent.mkdir(parents=True, exist_ok=True)
             im.save(out_filepath)


### PR DESCRIPTION
This PR adds a `make_video` optional argument to `StableDiffusionWalkPipeline.walk`. If `True`, a video is created from the generated images using `make_video_pyav` (current behavior). If `False`, the call to `make_video_pyav` is skipped and the video is not created. Default is `True`.

I can see two obvious cases where the user might want to set `make_video=False` and save storage space:
- The user might want to upscale the images with Real-ESRGAN before making the video (and he does not do it online because of VRAM limitations). The user might also want to do other kinds of post-processing before making the video.
- The user wants to use a different video encoder. I personally prefer calling `ffmpeg` instead of using `torchvision.io.write_video` as I find it much faster. I also don't like that the current solution loads all the images to memory into a single tensor before calling `torchvision.io.write_video`.

Another option could be to name the argument `skip_video_encoding` and set it to `False` by default.