### PR TITLE
Add better logging

### DIFF
--- a/stable_diffusion_videos/stable_diffusion_pipeline.py
+++ b/stable_diffusion_videos/stable_diffusion_pipeline.py
@@ -30,7 +30,9 @@ from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
 from .upsampling import RealESRGANModel
 from .utils import get_timesteps_arr, make_video_pyav, slerp
 
-logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+logging.set_verbosity_info()
+logger = logging.get_logger(__name__)
 
 
 class StableDiffusionWalkPipeline(DiffusionPipeline):

--- a/stable_diffusion_videos/stable_diffusion_pipeline.py
+++ b/stable_diffusion_videos/stable_diffusion_pipeline.py
@@ -776,7 +776,7 @@ class StableDiffusionWalkPipeline(DiffusionPipeline):
                 else None,
                 skip=skip,
                 negative_prompt=negative_prompt,
-                step=(i, len(prompts)-1),
+                step=(i, len(prompts) - 1),
             )
             make_video_pyav(
                 save_path,


### PR DESCRIPTION
This PR implements better video progress logging. Currently only the progress of the current image generation is being logged. So it's hard to tell how far from completion the entire video generation is. Below is an example of how the logs look (could be different depending on how you set up `logging` in your script):
```
Fetching 12 files: 100%|██████████| 12/12 [00:00<00:00, 563.35it/s]
[20:31:11] [0/2] [0/13] Generating frames 0-3
100%|██████████| 50/50 [00:18<00:00,  2.71it/s]
[20:31:31] [0/2] [1/13] Generating frames 4-7
100%|██████████| 50/50 [00:13<00:00,  3.68it/s]
[20:31:45] [0/2] [2/13] Generating frames 8-11
100%|██████████| 50/50 [00:13<00:00,  3.67it/s]
...
[20:36:44] [1/2] [10/13] Generating frames 40-43
100%|██████████| 50/50 [00:13<00:00,  3.64it/s]
[20:36:59] [1/2] [11/13] Generating frames 44-47
100%|██████████| 50/50 [00:13<00:00,  3.64it/s]
[20:37:13] [1/2] [12/13] Generating frames 48-49
100%|██████████| 50/50 [00:07<00:00,  6.81it/s]
```
In this example I set up `logging` like this:
```python
logging.basicConfig(
    level=logging.INFO,
    format='[%(asctime)s] %(message)s',
    datefmt='%H:%M:%S',
)
```
The new log messages are formatted as
```
[<walk_index>/<num_walks>] [<batch_index>/<num_batches>] Generating frame(s) <frame indexes>
```
where `<walk_index>` and `<num_walks>` refer to walks between two prompts.